### PR TITLE
fix type error caused with VSCode only

### DIFF
--- a/packages/jest-performance-testing/src/expectExtends.ts
+++ b/packages/jest-performance-testing/src/expectExtends.ts
@@ -1,15 +1,3 @@
 import * as extensions from './matchers';
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      toBeUpdatedWithin(expected: number | number[]): R;
-      toBeMounted(): R;
-      toBeMountedWithin(expected?: number): R;
-      toBeRenderedTimes(expected?: number): R;
-    }
-  }
-}
-
 expect.extend(extensions);

--- a/packages/jest-performance-testing/src/index.ts
+++ b/packages/jest-performance-testing/src/index.ts
@@ -1,1 +1,13 @@
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeUpdatedWithin(expected: number | number[]): R;
+      toBeMounted(): R;
+      toBeMountedWithin(expected?: number): R;
+      toBeRenderedTimes(expected?: number): R;
+    }
+  }
+}
+
 import './expectExtends';


### PR DESCRIPTION
If import `jest-performance-testing` in the file set in `setupFilesAfterEnv`, I will get the following type error.

```ts
// setup.ts
import '@testing-library/jest-dom';
import 'jest-performance-testing';
```

<img width="986" alt="スクリーンショット 2020-08-20 1 49 42" src="https://user-images.githubusercontent.com/12913947/90665807-851db380-e287-11ea-8e2a-c46da55422d1.png">

You can avoid this error by ambient declaring it in the top root declaration file (`dist/jest-performance-testing/src/index.d.ts`) .